### PR TITLE
Optimizations based on profiling 

### DIFF
--- a/type_adapter.go
+++ b/type_adapter.go
@@ -12,10 +12,8 @@ var _ types.Adapter = TypeAdapter{}
 type TypeAdapter map[reflect.Type]func(value any) ref.Val
 
 func (ta TypeAdapter) NativeToValue(value any) ref.Val {
-	for typ, fn := range ta {
-		if reflect.TypeOf(value) == typ {
-			return fn(value)
-		}
+	if fn, ok := ta[reflect.TypeOf(value)]; ok {
+		return fn(value)
 	}
 	return types.DefaultTypeAdapter.NativeToValue(value)
 }

--- a/type_adapter.go
+++ b/type_adapter.go
@@ -12,6 +12,9 @@ var _ types.Adapter = TypeAdapter{}
 type TypeAdapter map[reflect.Type]func(value any) ref.Val
 
 func (ta TypeAdapter) NativeToValue(value any) ref.Val {
+	if rv, ok := value.(ref.Val); ok {
+		return rv
+	}
 	if fn, ok := ta[reflect.TypeOf(value)]; ok {
 		return fn(value)
 	}


### PR DESCRIPTION
Optimize the evaluation hot path to reduce per-evaluation allocations and overhead.

eliminating redundant work that was done on every Eval() call.